### PR TITLE
total supplied values now displayed in millions to match kava page & for better mobile view

### DIFF
--- a/hard-protocol-home.js
+++ b/hard-protocol-home.js
@@ -27,6 +27,12 @@ const noDollarSign = (value) => {
   return value.slice(1, value.length);
 }
 
+const displayInMillions = (value) => {
+  const valueInMil = value/FACTOR_SIX;
+  const valueInMilUsd = usdFormatter.format(valueInMil);
+  return valueInMilUsd + "M";
+}
+
 const formatCssId = (value, denom) => {
   let displayDenom;
   switch(denom) {
@@ -224,8 +230,8 @@ const setTotalSuppliedDisplayValues = async (denoms, siteData, cssIds) => {
     const currencyValue = suppliedHardAmount / denomConversions[denom];
 
     const usdValue = currencyValue * prices[denom].price;
-    const formattedUsdValue = usdFormatter.format(usdValue);
-    setDisplayValueById(cssId, formattedUsdValue);
+    const denomTotalSupplied = displayInMillions(usdValue);
+    setDisplayValueById(cssId, denomTotalSupplied);
   }
 };
 
@@ -344,6 +350,8 @@ const updateDisplayValues = async(denoms) => {
 
   const hardSupplyRewardsPerYearByDenom = await getRewardPerYearByDenom(siteData);
   siteData['hardSupplyRewardsPerYearByDenom'] = hardSupplyRewardsPerYearByDenom;
+
+  console.log(siteData)
 
   // set display values in ui
   await setTotalAssetValueDisplayValue(siteData, cssIds);

--- a/hard-protocol-home.js
+++ b/hard-protocol-home.js
@@ -33,6 +33,12 @@ const displayInMillions = (value) => {
   return valueInMilUsd + "M";
 }
 
+const displayInThousands = (value) => {
+  const valueInK = value/Number(10 ** 3);
+  const valueInKUsd = usdFormatter.format(valueInK);
+  return valueInKUsd + "K";
+}
+
 const formatCssId = (value, denom) => {
   let displayDenom;
   switch(denom) {
@@ -246,8 +252,8 @@ const setTotalBorrowedDisplayValues = async (denoms, siteData, cssIds) => {
     const currencyValue = borrowedHardAmount / denomConversions[denom];
 
     const usdValue = currencyValue * prices[denom].price;
-    const formattedUsdValue = usdFormatter.format(usdValue);
-    setDisplayValueById(cssId, formattedUsdValue);
+    const denomTotalSupplied = displayInThousands(usdValue);
+    setDisplayValueById(cssId, denomTotalSupplied);
   }
 };
 

--- a/hard-protocol-home.js
+++ b/hard-protocol-home.js
@@ -252,7 +252,7 @@ const setTotalBorrowedDisplayValues = async (denoms, siteData, cssIds) => {
     const currencyValue = borrowedHardAmount / denomConversions[denom];
 
     const usdValue = currencyValue * prices[denom].price;
-    const denomTotalSupplied = displayInThousands(usdValue);
+    const denomTotalSupplied = usdValue >= 10 ** 6 ? displayInMillions(usdValue) : displayInThousands(usdValue);
     setDisplayValueById(cssId, denomTotalSupplied);
   }
 };

--- a/hard-protocol-home.js
+++ b/hard-protocol-home.js
@@ -351,8 +351,6 @@ const updateDisplayValues = async(denoms) => {
   const hardSupplyRewardsPerYearByDenom = await getRewardPerYearByDenom(siteData);
   siteData['hardSupplyRewardsPerYearByDenom'] = hardSupplyRewardsPerYearByDenom;
 
-  console.log(siteData)
-
   // set display values in ui
   await setTotalAssetValueDisplayValue(siteData, cssIds);
   await setTotalHardDistributedDisplayValue(siteData, cssIds);


### PR DESCRIPTION
[Ticket](https://app.asana.com/0/1200070757865857/1200392365772125
)

[Preview](https://kava-staging-03-21.webflow.io/hard-protocol)

1. stats should be aligned vertically and not overlapping with each other
2. all stats should be visible on screen with horizontal scrolling
3. Display dollar amounts in this format X.XX in millions $ (see [kava protocol](https://www.kava.io/kava-protocol) stats for reference)
4. If value is less than 1 million, display in format + "K"

<img width="728" alt="Screen Shot 2021-05-27 at 11 55 54 AM" src="https://user-images.githubusercontent.com/67024033/119866506-7fbe5b00-bee2-11eb-8515-1569e8b5afea.png">

