### PR TITLE
formatting numbers less than $1M with +K

### DIFF
--- a/kava-protocol-home.js
+++ b/kava-protocol-home.js
@@ -411,7 +411,7 @@ const setTotalLockedDisplayValues = async (denoms, siteData, cssIds) => {
     const denomTotalSupplyCoin = denomSupplyFromAcct/factor;
     const denomTotalSupplyValue = Number(denomTotalSupplyCoin * price);
 
-    const denomTotalLocked = displayInMillions(denomTotalSupplyValue);
+    const denomTotalLocked = denomTotalSupplyValue >= 10 ** 6 ? >= 10 ** 6 ? displayInMillions(denomTotalSupplyValue) : displayInThousands(denomTotalSupplyValue);;
     setDisplayValueById(cssId, denomTotalLocked)
   }
 }

--- a/kava-protocol-home.js
+++ b/kava-protocol-home.js
@@ -69,6 +69,12 @@ const displayInMillions = (value) => {
   return valueInMilUsd + "M";
 }
 
+const displayInThousands = (value) => {
+  const valueInK = value/Number(10 ** 3);
+  const valueInKUsd = usdFormatter.format(valueInK);
+  return valueInKUsd + "K";
+}
+
 const isKavaNativeAsset = (denom) => {
   return ['ukava-a', 'usdx', 'hard', 'ukava', 'hard-a'].includes(denom)
 }
@@ -387,7 +393,7 @@ const setTotalBorrowedDisplayValues = async (denoms, siteData, cssIds) => {
     const usdxBorrowed = siteData['usdxBorrowed'][denom];
     const cssId = cssIds[denom]['totalBorrowed'];
 
-    const denomTotalBorrowed = displayInMillions(usdxBorrowed);
+    const denomTotalBorrowed = usdxBorrowed >= 10 ** 6 ? displayInMillions(usdxBorrowed) : displayInThousands(usdxBorrowed);
     setDisplayValueById(cssId, denomTotalBorrowed)
   }
 }

--- a/kava-protocol-home.js
+++ b/kava-protocol-home.js
@@ -411,7 +411,7 @@ const setTotalLockedDisplayValues = async (denoms, siteData, cssIds) => {
     const denomTotalSupplyCoin = denomSupplyFromAcct/factor;
     const denomTotalSupplyValue = Number(denomTotalSupplyCoin * price);
 
-    const denomTotalLocked = denomTotalSupplyValue >= 10 ** 6 ? >= 10 ** 6 ? displayInMillions(denomTotalSupplyValue) : displayInThousands(denomTotalSupplyValue);;
+    const denomTotalLocked = displayInMillions(denomTotalSupplyValue);
     setDisplayValueById(cssId, denomTotalLocked)
   }
 }

--- a/kava-protocol-home.js
+++ b/kava-protocol-home.js
@@ -411,7 +411,7 @@ const setTotalLockedDisplayValues = async (denoms, siteData, cssIds) => {
     const denomTotalSupplyCoin = denomSupplyFromAcct/factor;
     const denomTotalSupplyValue = Number(denomTotalSupplyCoin * price);
 
-    const denomTotalLocked = displayInMillions(denomTotalSupplyValue);
+    const denomTotalLocked = denomTotalSupplyValue >= 10 ** 6 ? displayInMillions(denomTotalSupplyValue) : displayInThousands(denomTotalSupplyValue);
     setDisplayValueById(cssId, denomTotalLocked)
   }
 }


### PR DESCRIPTION
[Ticket](https://app.asana.com/0/1189045082777889/1200492177477416)

For "Total Borrow" numbers less than $1M, display the data in thousands instead of millions

Before
<img width="614" alt="Screen Shot 2021-06-22 at 12 57 22 PM" src="https://user-images.githubusercontent.com/67024033/122975847-64b3ff00-d359-11eb-9c27-eddc41feb23c.png">

After
<img width="614" alt="Screen Shot 2021-06-22 at 1 10 19 PM" src="https://user-images.githubusercontent.com/67024033/122977581-333c3300-d35b-11eb-99c4-1e59d87e5d37.png">



