### PR TITLE
Adding Swap Asset Row to Stats Page

### DIFF
--- a/kava-stats.js
+++ b/kava-stats.js
@@ -727,8 +727,13 @@ const setMarketCapDisplayValues = async (denoms, siteData, cssIds) => {
   for (const denom of denoms) {
     const price = prices[denom].price
     const suppliedCoin = defiCoinsSupply[denom]
+    if (denom === 'swp') {
+      siteData['suppliedAmounts']['swp'].amount = suppliedCoin;
+    }
+
     const suppliedDenomUsd = suppliedCoin * price;
     total += suppliedDenomUsd
+
 
     const desktopCssId = cssIds[denom]['marketCap']['d']
     const mobileCssId = cssIds[denom]['marketCap']['m']

--- a/kava-stats.js
+++ b/kava-stats.js
@@ -526,14 +526,14 @@ const mapUsdxMarketData = async (usdxMarketJson) => {
   return usdxMarketJson.market_data.price_change_percentage_24h
 }
 
-// const setSwpSupplyAmount = async (supplyTotalJson) => {
-//   const swpSupplyAmount = Number(supplyTotalJson.result.find(coin => coin.denom === 'swp').amount);
-//
-//   return {
-//     denom: 'swp',
-//     amount: swpSupplyAmount
-//   }
-// };
+const setSwpSupplyAmount = async (supplyTotalJson) => {
+  const swpSupplyAmount = Number(supplyTotalJson.result.find(coin => coin.denom === 'swp').amount);
+
+  return {
+    denom: 'swp',
+    amount: swpSupplyAmount
+  }
+};
 
 const setSwpPoolPrice = async (swpMarketDataJson) => {
   const usdxReserveAmount =  swpMarketDataJson.result.coins.find(coin => coin.denom === 'usdx').amount / FACTOR_SIX;
@@ -928,8 +928,8 @@ const updateDisplayValues = async (denoms) => {
   const supplyData = mapSuppliedAmounts(denoms, supplyTotalJson.result);
   siteData['supplyData'] = supplyData;
 
-  // const suppliedSwpAmount = await setSwpSupplyAmount(supplyTotalJson);
-  // siteData['supplyData']['swp'] = suppliedSwpAmount;
+  const suppliedSwpAmount = await setSwpSupplyAmount(supplyTotalJson);
+  siteData['supplyData']['swp'] = suppliedSwpAmount;
 
   const bep3SupplyData = await mapBep3Supplies(denoms, bep3SupplyJson.result);
   siteData['bep3SupplyData'] = bep3SupplyData;

--- a/kava-stats.js
+++ b/kava-stats.js
@@ -526,14 +526,14 @@ const mapUsdxMarketData = async (usdxMarketJson) => {
   return usdxMarketJson.market_data.price_change_percentage_24h
 }
 
-const setSwpSupplyAmount = async (supplyTotalJson) => {
-  const swpSupplyAmount = Number(supplyTotalJson.result.find(coin => coin.denom === 'swp').amount);
-
-  return {
-    denom: 'swp',
-    amount: swpSupplyAmount
-  }
-};
+// const setSwpSupplyAmount = async (supplyTotalJson) => {
+//   const swpSupplyAmount = Number(supplyTotalJson.result.find(coin => coin.denom === 'swp').amount);
+//
+//   return {
+//     denom: 'swp',
+//     amount: swpSupplyAmount
+//   }
+// };
 
 const setSwpPoolPrice = async (swpMarketDataJson) => {
   const usdxReserveAmount =  swpMarketDataJson.result.coins.find(coin => coin.denom === 'usdx').amount / FACTOR_SIX;
@@ -727,7 +727,6 @@ const setMarketCapDisplayValues = async (denoms, siteData, cssIds) => {
   for (const denom of denoms) {
     const price = prices[denom].price
     const suppliedCoin = defiCoinsSupply[denom]
-
     const suppliedDenomUsd = suppliedCoin * price;
     total += suppliedDenomUsd
 
@@ -929,8 +928,8 @@ const updateDisplayValues = async (denoms) => {
   const supplyData = mapSuppliedAmounts(denoms, supplyTotalJson.result);
   siteData['supplyData'] = supplyData;
 
-  const suppliedSwpAmount = await setSwpSupplyAmount(supplyTotalJson);
-  siteData['supplyData']['swp'] = suppliedSwpAmount;
+  // const suppliedSwpAmount = await setSwpSupplyAmount(supplyTotalJson);
+  // siteData['supplyData']['swp'] = suppliedSwpAmount;
 
   const bep3SupplyData = await mapBep3Supplies(denoms, bep3SupplyJson.result);
   siteData['bep3SupplyData'] = bep3SupplyData;

--- a/kava-stats.js
+++ b/kava-stats.js
@@ -454,7 +454,6 @@ const mapSuppliedAmounts = (denoms, coins) => {
     let coin = emptyCoin(denom);
 
     const accountCoin = mappedCoins[denom]
-
     if(accountCoin) {
       coin = { denom: commonDenomMapper(accountCoin.denom), amount: Number(accountCoin.amount) }
     }
@@ -507,7 +506,6 @@ const mapBep3Params = async (denoms, bep3ParamsData, siteData) => {
 }
 
 const mapSupplyAndMarket = async (denoms, siteData) => {
-  // siteData['supplyData']['swp'] = siteData['suppliedAmounts']['swp'];
   const supplydata = siteData['supplyData']
   const bep3SupplyData = siteData['bep3SupplyData']
   const denomConversions = siteData['denomConversions']
@@ -528,14 +526,14 @@ const mapUsdxMarketData = async (usdxMarketJson) => {
   return usdxMarketJson.market_data.price_change_percentage_24h
 }
 
-const setSwpSupplyAmount = async (supplyTotalJson) => {
-  const swpSupplyAmount = Number(supplyTotalJson.result.find(coin => coin.denom === 'swp').amount);
-
-  return {
-    denom: 'swp',
-    amount: swpSupplyAmount
-  }
-};
+// const setSwpSupplyAmount = async (supplyTotalJson) => {
+//   const swpSupplyAmount = Number(supplyTotalJson.result.find(coin => coin.denom === 'swp').amount);
+//
+//   return {
+//     denom: 'swp',
+//     amount: swpSupplyAmount
+//   }
+// };
 
 const setSwpPoolPrice = async (swpMarketDataJson) => {
   const usdxReserveAmount =  swpMarketDataJson.result.coins.find(coin => coin.denom === 'usdx').amount / FACTOR_SIX;
@@ -721,7 +719,7 @@ const setTotalAssetsBorrowedDisplayValue = async (siteData, cssIds) => {
 
 const setMarketCapDisplayValues = async (denoms, siteData, cssIds) => {
   const defiCoinsSupply = siteData['defiCoinsSupply'];
-  const swpSupply = siteData['supplyData']['swp'].amount
+  // const swpSupply = siteData['supplyData']['swp'].amount
   const prices = siteData['prices'];
   const cssId = cssIds['totalMarketCap'];
 
@@ -729,11 +727,11 @@ const setMarketCapDisplayValues = async (denoms, siteData, cssIds) => {
 
   for (const denom of denoms) {
     const price = prices[denom].price
-    let suppliedCoin = defiCoinsSupply[denom]
+    const suppliedCoin = defiCoinsSupply[denom]
 
-    if (denom === 'swp') {
-      suppliedCoin = swpSupply / FACTOR_SIX;
-    }
+    // if (denom === 'swp') {
+    //   suppliedCoin = swpSupply / FACTOR_SIX;
+    // }
 
     const suppliedDenomUsd = suppliedCoin * price;
     total += suppliedDenomUsd
@@ -936,8 +934,8 @@ const updateDisplayValues = async (denoms) => {
   const supplyData = mapSuppliedAmounts(denoms, supplyTotalJson.result);
   siteData['supplyData'] = supplyData;
 
-  const suppliedSwpAmount = await setSwpSupplyAmount(supplyTotalJson);
-  siteData['supplyData']['swp'] = suppliedSwpAmount;
+  // const suppliedSwpAmount = await setSwpSupplyAmount(supplyTotalJson);
+  // siteData['supplyData']['swp'] = suppliedSwpAmount;
 
   const bep3SupplyData = await mapBep3Supplies(denoms, bep3SupplyJson.result);
   siteData['bep3SupplyData'] = bep3SupplyData;
@@ -947,6 +945,8 @@ const updateDisplayValues = async (denoms) => {
 
   const defiCoinsSupply = await mapSupplyAndMarket(denoms, siteData)
   siteData['defiCoinsSupply'] = defiCoinsSupply;
+
+  console.log('siteData', siteData)
 
   // set display values
   await setTotalEarningsDisplayValues(denoms, siteData, cssIds)

--- a/kava-stats.js
+++ b/kava-stats.js
@@ -512,10 +512,9 @@ const mapSupplyAndMarket = async (denoms, siteData) => {
   const denomConversions = siteData['denomConversions']
 
   const coins = { }
-
   for (const denom of denoms) {
     // think we do this because of the double spend?
-    let denomTotalSupply = denom === 'bnb-a' ? bep3SupplyData[denom] : supplydata[denom].amount
+    const denomTotalSupply = denom === 'bnb-a' ? bep3SupplyData[denom] : supplydata[denom].amount
     const factor = denomConversions[denom]
 
     const denomTotalSupplyCoin = denomTotalSupply / factor
@@ -940,8 +939,6 @@ const updateDisplayValues = async (denoms) => {
   const supplyData = mapSuppliedAmounts(denoms, supplyTotalJson.result);
   siteData['supplyData'] = supplyData;
 
-  const swpSupplyData = suppliedSwpAmount;
-
   const bep3SupplyData = await mapBep3Supplies(denoms, bep3SupplyJson.result);
   siteData['bep3SupplyData'] = bep3SupplyData;
 
@@ -950,10 +947,6 @@ const updateDisplayValues = async (denoms) => {
 
   const defiCoinsSupply = await mapSupplyAndMarket(denoms, siteData)
   siteData['defiCoinsSupply'] = defiCoinsSupply;
-
-  console.log('siteData', siteData)
-
-  console.log('cssIds', cssIds)
 
   // set display values
   await setTotalEarningsDisplayValues(denoms, siteData, cssIds)

--- a/kava-stats.js
+++ b/kava-stats.js
@@ -147,15 +147,15 @@ var denomLabel = (v) => {
   }
 }
 
-var bnbAmountOnPlatform = (data) => {
-  const denomData = data.result.find((d) => d.current_supply.denom === 'bnb')
-  return Number(denomData.current_supply.amount)
-}
-
-var totalAmountOnPlatformByDenom = (data, denom) => {
-  const denomData = data.result.find((d) => d.denom === denom)
-  return Number(denomData.amount)
-}
+// var bnbAmountOnPlatform = (data) => {
+//   const denomData = data.result.find((d) => d.current_supply.denom === 'bnb')
+//   return Number(denomData.current_supply.amount)
+// }
+//
+// var totalAmountOnPlatformByDenom = (data, denom) => {
+//   const denomData = data.result.find((d) => d.denom === denom)
+//   return Number(denomData.amount)
+// }
 
 // var supplyLimitByDenom = (denom, bep3ParamsDataOld) => {
 //   const assetParams = bep3ParamsDataOld.result.asset_params;
@@ -518,7 +518,6 @@ const mapSupplyAndMarket = async (denoms, siteData) => {
     const factor = denomConversions[denom]
 
     const denomTotalSupplyCoin = denomTotalSupply / factor
-
     coins[denom] = denomTotalSupplyCoin
   }
   return coins
@@ -746,25 +745,25 @@ const setMarketCapDisplayValues = async (denoms, siteData, cssIds) => {
   }
   setDisplayValueById(cssId, noDollarSign(usdFormatter.format(total)))
 }
-
-var setDenomTotalSupplyValue = async (supplyDataOld, denomPrice, platformDenom) => {
-  let denomTotalSupply;
-  platformDenom === 'bnb' ?
-    denomTotalSupply = bnbAmountOnPlatform(supplyDataOld) :
-    denomTotalSupply = totalAmountOnPlatformByDenom(supplyDataOld, platformDenom)
-  let denomTotalSupplyConverted
-  isKavaNativeAsset(platformDenom) ?
-    denomTotalSupplyConverted = Number(denomTotalSupply)/FACTOR_SIX :
-    denomTotalSupplyConverted = Number(denomTotalSupply)/FACTOR_EIGHT
-  let denomTotalSupplyValue =  Number(denomTotalSupplyConverted * denomPrice)
-
-  let data = {}
-  data[`${platformDenom}Usd`] = denomTotalSupplyValue
-  data[`${platformDenom}MarketCap`] = formatMoneyMillions(denomTotalSupplyValue)
-  data[`${platformDenom}Supply`] = formatMoneyNoDecimalsOrLabels(denomTotalSupplyConverted) + ' ' + denomLabel(platformDenom)
-
-  return data;
-};
+//
+// var setDenomTotalSupplyValue = async (supplyDataOld, denomPrice, platformDenom) => {
+//   let denomTotalSupply;
+//   platformDenom === 'bnb' ?
+//     denomTotalSupply = bnbAmountOnPlatform(supplyDataOld) :
+//     denomTotalSupply = totalAmountOnPlatformByDenom(supplyDataOld, platformDenom)
+//   let denomTotalSupplyConverted
+//   isKavaNativeAsset(platformDenom) ?
+//     denomTotalSupplyConverted = Number(denomTotalSupply)/FACTOR_SIX :
+//     denomTotalSupplyConverted = Number(denomTotalSupply)/FACTOR_EIGHT
+//   let denomTotalSupplyValue =  Number(denomTotalSupplyConverted * denomPrice)
+//
+//   let data = {}
+//   data[`${platformDenom}Usd`] = denomTotalSupplyValue
+//   data[`${platformDenom}MarketCap`] = formatMoneyMillions(denomTotalSupplyValue)
+//   data[`${platformDenom}Supply`] = formatMoneyNoDecimalsOrLabels(denomTotalSupplyConverted) + ' ' + denomLabel(platformDenom)
+//
+//   return data;
+// };
 
 const setSupplyDisplayValues = async (denoms, siteData, cssIds) => {
   const defiCoinsSupply = siteData['defiCoinsSupply']

--- a/kava-stats.js
+++ b/kava-stats.js
@@ -525,6 +525,16 @@ const mapSupplyAndMarket = async (denoms, siteData) => {
 const mapUsdxMarketData = async (usdxMarketJson) => {
   return usdxMarketJson.market_data.price_change_percentage_24h
 }
+
+const setSwpSupplyAmount = async (swpMarketDataJson) => {
+  const swpSupplyAmount = Number(swpMarketDataJson.result.coins.find(coin => coin.denom === 'swp').amount);
+
+  return {
+    denom: 'swp',
+    amount: swpSupplyAmount
+  }
+};
+
 const setSwpPoolPrice = async (swpMarketDataJson) => {
   const usdxReserveAmount =  swpMarketDataJson.result.coins.find(coin => coin.denom === 'usdx').amount / FACTOR_SIX;
   const swpReserveAmount =  swpMarketDataJson.result.coins.find(coin => coin.denom === 'swp').amount / FACTOR_SIX;
@@ -534,10 +544,7 @@ const setSwpPoolPrice = async (swpMarketDataJson) => {
   return {
     price: swpPrice
   };
-}
-
-
-// const swpPoolReserves = swpMarketDataJson.result.coins.find(coin => coin.denom === 'usdx').amount;
+};
 
 
 const setTotalEarningsDisplayValues = async (denoms, siteData, cssIds) => {
@@ -854,6 +861,7 @@ const updateDisplayValues = async (denoms) => {
   const usdxMarketDataJson = await usdxMarketResponse.json();
   const swpMarketDataJson = await swpMarketResponse.json();
 
+
   const platformAmounts = {
     'bnb-a': await bnbPlatformAmountsJson.result,
     'btcb-a': await btcPlatformAmountsJson.result,
@@ -913,6 +921,9 @@ const updateDisplayValues = async (denoms) => {
 
   const suppliedAmounts = mapSuppliedAmounts(denoms, suppliedAmountJson.result.value.coins);
   siteData['suppliedAmounts'] = suppliedAmounts;
+
+  const suppliedSwpAmount = await setSwpSupplyAmount(swpMarketDataJson);
+  siteData['suppliedAmounts']['swp'] = suppliedSwpAmount;
 
   const totalSuppliedData = await mapDenomTotalSupplied(denoms, siteData)
   siteData['totalSuppliedData'] = totalSuppliedData;

--- a/kava-stats.js
+++ b/kava-stats.js
@@ -934,8 +934,8 @@ const updateDisplayValues = async (denoms) => {
   const supplyData = mapSuppliedAmounts(denoms, supplyTotalJson.result);
   siteData['supplyData'] = supplyData;
 
-  // const suppliedSwpAmount = await setSwpSupplyAmount(supplyTotalJson);
-  // siteData['supplyData']['swp'] = suppliedSwpAmount;
+  const suppliedSwpAmount = await setSwpSupplyAmount(supplyTotalJson);
+  siteData['supplyData']['swp'] = suppliedSwpAmount;
 
   const bep3SupplyData = await mapBep3Supplies(denoms, bep3SupplyJson.result);
   siteData['bep3SupplyData'] = bep3SupplyData;

--- a/kava-stats.js
+++ b/kava-stats.js
@@ -506,17 +506,20 @@ const mapBep3Params = async (denoms, bep3ParamsData, siteData) => {
 }
 
 const mapSupplyAndMarket = async (denoms, siteData) => {
+  siteData['supplyData']['swp'] = siteData['suppliedAmounts']['swp'];
   const supplydata = siteData['supplyData']
   const bep3SupplyData = siteData['bep3SupplyData']
   const denomConversions = siteData['denomConversions']
 
   const coins = { }
+
   for (const denom of denoms) {
     // think we do this because of the double spend?
-    const denomTotalSupply = denom === 'bnb-a' ? bep3SupplyData[denom] : supplydata[denom].amount
+    let denomTotalSupply = denom === 'bnb-a' ? bep3SupplyData[denom] : supplydata[denom].amount
     const factor = denomConversions[denom]
 
     const denomTotalSupplyCoin = denomTotalSupply / factor
+
     coins[denom] = denomTotalSupplyCoin
   }
   return coins
@@ -718,22 +721,23 @@ const setTotalAssetsBorrowedDisplayValue = async (siteData, cssIds) => {
 }
 
 const setMarketCapDisplayValues = async (denoms, siteData, cssIds) => {
-  const defiCoinsSupply = siteData['defiCoinsSupply']
-  const prices = siteData['prices']
-  const cssId = cssIds['totalMarketCap']
+  const defiCoinsSupply = siteData['defiCoinsSupply'];
+  const swpSupply = siteData['suppliedAmounts']['swp'].amount
+  const prices = siteData['prices'];
+  const cssId = cssIds['totalMarketCap'];
 
   let total = 0;
 
   for (const denom of denoms) {
     const price = prices[denom].price
-    const suppliedCoin = defiCoinsSupply[denom]
+    let suppliedCoin = defiCoinsSupply[denom]
+
     if (denom === 'swp') {
-      siteData['suppliedAmounts']['swp'].amount = suppliedCoin;
+      suppliedCoin = swpSupply;
     }
 
     const suppliedDenomUsd = suppliedCoin * price;
     total += suppliedDenomUsd
-
 
     const desktopCssId = cssIds[denom]['marketCap']['d']
     const mobileCssId = cssIds[denom]['marketCap']['m']
@@ -935,6 +939,8 @@ const updateDisplayValues = async (denoms) => {
 
   const supplyData = mapSuppliedAmounts(denoms, supplyTotalJson.result);
   siteData['supplyData'] = supplyData;
+
+  const swpSupplyData = suppliedSwpAmount;
 
   const bep3SupplyData = await mapBep3Supplies(denoms, bep3SupplyJson.result);
   siteData['bep3SupplyData'] = bep3SupplyData;

--- a/kava-stats.js
+++ b/kava-stats.js
@@ -720,7 +720,7 @@ const setTotalAssetsBorrowedDisplayValue = async (siteData, cssIds) => {
 
 const setMarketCapDisplayValues = async (denoms, siteData, cssIds) => {
   const defiCoinsSupply = siteData['defiCoinsSupply'];
-  const swpSupply = siteData['suppliedAmounts']['swp'].amount
+  const swpSupply = siteData['supplyData']['swp'].amount
   const prices = siteData['prices'];
   const cssId = cssIds['totalMarketCap'];
 

--- a/kava-stats.js
+++ b/kava-stats.js
@@ -506,7 +506,7 @@ const mapBep3Params = async (denoms, bep3ParamsData, siteData) => {
 }
 
 const mapSupplyAndMarket = async (denoms, siteData) => {
-  siteData['supplyData']['swp'] = siteData['suppliedAmounts']['swp'];
+  // siteData['supplyData']['swp'] = siteData['suppliedAmounts']['swp'];
   const supplydata = siteData['supplyData']
   const bep3SupplyData = siteData['bep3SupplyData']
   const denomConversions = siteData['denomConversions']

--- a/kava-stats.js
+++ b/kava-stats.js
@@ -719,7 +719,6 @@ const setTotalAssetsBorrowedDisplayValue = async (siteData, cssIds) => {
 
 const setMarketCapDisplayValues = async (denoms, siteData, cssIds) => {
   const defiCoinsSupply = siteData['defiCoinsSupply'];
-  // const swpSupply = siteData['supplyData']['swp'].amount
   const prices = siteData['prices'];
   const cssId = cssIds['totalMarketCap'];
 
@@ -728,10 +727,6 @@ const setMarketCapDisplayValues = async (denoms, siteData, cssIds) => {
   for (const denom of denoms) {
     const price = prices[denom].price
     const suppliedCoin = defiCoinsSupply[denom]
-
-    // if (denom === 'swp') {
-    //   suppliedCoin = swpSupply / FACTOR_SIX;
-    // }
 
     const suppliedDenomUsd = suppliedCoin * price;
     total += suppliedDenomUsd
@@ -945,8 +940,6 @@ const updateDisplayValues = async (denoms) => {
 
   const defiCoinsSupply = await mapSupplyAndMarket(denoms, siteData)
   siteData['defiCoinsSupply'] = defiCoinsSupply;
-
-  console.log('siteData', siteData)
 
   // set display values
   await setTotalEarningsDisplayValues(denoms, siteData, cssIds)

--- a/kava-stats.js
+++ b/kava-stats.js
@@ -526,14 +526,14 @@ const mapUsdxMarketData = async (usdxMarketJson) => {
   return usdxMarketJson.market_data.price_change_percentage_24h
 }
 
-// const setSwpSupplyAmount = async (supplyTotalJson) => {
-//   const swpSupplyAmount = Number(supplyTotalJson.result.find(coin => coin.denom === 'swp').amount);
-//
-//   return {
-//     denom: 'swp',
-//     amount: swpSupplyAmount
-//   }
-// };
+const setSwpSupplyAmount = async (supplyTotalJson) => {
+  const swpSupplyAmount = Number(supplyTotalJson.result.find(coin => coin.denom === 'swp').amount);
+
+  return {
+    denom: 'swp',
+    amount: swpSupplyAmount
+  }
+};
 
 const setSwpPoolPrice = async (swpMarketDataJson) => {
   const usdxReserveAmount =  swpMarketDataJson.result.coins.find(coin => coin.denom === 'usdx').amount / FACTOR_SIX;

--- a/kava-stats.js
+++ b/kava-stats.js
@@ -733,7 +733,7 @@ const setMarketCapDisplayValues = async (denoms, siteData, cssIds) => {
     let suppliedCoin = defiCoinsSupply[denom]
 
     if (denom === 'swp') {
-      suppliedCoin = swpSupply;
+      suppliedCoin = swpSupply / FACTOR_SIX;
     }
 
     const suppliedDenomUsd = suppliedCoin * price;

--- a/kava-stats.js
+++ b/kava-stats.js
@@ -147,33 +147,33 @@ var denomLabel = (v) => {
   }
 }
 
-// var bnbAmountOnPlatform = (data) => {
-//   const denomData = data.result.find((d) => d.current_supply.denom === 'bnb')
-//   return Number(denomData.current_supply.amount)
-// }
-//
-// var totalAmountOnPlatformByDenom = (data, denom) => {
-//   const denomData = data.result.find((d) => d.denom === denom)
-//   return Number(denomData.amount)
-// }
+var bnbAmountOnPlatform = (data) => {
+  const denomData = data.result.find((d) => d.current_supply.denom === 'bnb')
+  return Number(denomData.current_supply.amount)
+}
 
-// var supplyLimitByDenom = (denom, bep3ParamsDataOld) => {
-//   const assetParams = bep3ParamsDataOld.result.asset_params;
-//
-//   const denomParams = assetParams.find(
-//     (item) => item.denom.toUpperCase() === denom.toUpperCase()
-//   );
-//
-//   let hasSupplyLimit = denomParams && denomParams.supply_limit && denomParams.supply_limit.limit;
-//   return hasSupplyLimit ? (Number(denomParams.supply_limit.limit)/FACTOR_EIGHT) : 0
-// };
-//
-// var setDenomTotalSupplied = (denomSupplyFromAcct, factor, denomPrice, denomLockedId) => {
-//   const denomTotalSupplyCoin = denomSupplyFromAcct/factor;
-//   const denomTotalSupplyValue = Number(denomTotalSupplyCoin * denomPrice);
-//   setDisplayValue(noDollarSign(denomTotalSupplyValue), denomLockedId);
-//   return denomTotalSupplyValue
-// }
+var totalAmountOnPlatformByDenom = (data, denom) => {
+  const denomData = data.result.find((d) => d.denom === denom)
+  return Number(denomData.amount)
+}
+
+var supplyLimitByDenom = (denom, bep3ParamsDataOld) => {
+  const assetParams = bep3ParamsDataOld.result.asset_params;
+
+  const denomParams = assetParams.find(
+    (item) => item.denom.toUpperCase() === denom.toUpperCase()
+  );
+
+  let hasSupplyLimit = denomParams && denomParams.supply_limit && denomParams.supply_limit.limit;
+  return hasSupplyLimit ? (Number(denomParams.supply_limit.limit)/FACTOR_EIGHT) : 0
+};
+
+var setDenomTotalSupplied = (denomSupplyFromAcct, factor, denomPrice, denomLockedId) => {
+  const denomTotalSupplyCoin = denomSupplyFromAcct/factor;
+  const denomTotalSupplyValue = Number(denomTotalSupplyCoin * denomPrice);
+  setDisplayValue(noDollarSign(denomTotalSupplyValue), denomLockedId);
+  return denomTotalSupplyValue
+}
 
 const setDenomTotalSuppliedDisplayValues = async (denoms, siteData, cssIds) => {
   const totalSuppliedData = siteData['totalSuppliedData']
@@ -453,15 +453,7 @@ const mapSuppliedAmounts = (denoms, coins) => {
   for(const denom of denoms) {
     let coin = emptyCoin(denom);
 
-    let accountCoin = mappedCoins[denom]
-    // if (denom === 'swp') {
-    //   const swapSuppliedAmount = coins.find(coin => coin.denom === 'swp').amount
-    //   // console.log('swapSuppliedAmount', swapSuppliedAmount)
-    //   accountCoin = {
-    //     denom: 'swp',
-    //     amount: swapSuppliedAmount
-    //   }
-    // }
+    const accountCoin = mappedCoins[denom]
 
     if(accountCoin) {
       coin = { denom: commonDenomMapper(accountCoin.denom), amount: Number(accountCoin.amount) }
@@ -754,25 +746,25 @@ const setMarketCapDisplayValues = async (denoms, siteData, cssIds) => {
   }
   setDisplayValueById(cssId, noDollarSign(usdFormatter.format(total)))
 }
-//
-// var setDenomTotalSupplyValue = async (supplyDataOld, denomPrice, platformDenom) => {
-//   let denomTotalSupply;
-//   platformDenom === 'bnb' ?
-//     denomTotalSupply = bnbAmountOnPlatform(supplyDataOld) :
-//     denomTotalSupply = totalAmountOnPlatformByDenom(supplyDataOld, platformDenom)
-//   let denomTotalSupplyConverted
-//   isKavaNativeAsset(platformDenom) ?
-//     denomTotalSupplyConverted = Number(denomTotalSupply)/FACTOR_SIX :
-//     denomTotalSupplyConverted = Number(denomTotalSupply)/FACTOR_EIGHT
-//   let denomTotalSupplyValue =  Number(denomTotalSupplyConverted * denomPrice)
-//
-//   let data = {}
-//   data[`${platformDenom}Usd`] = denomTotalSupplyValue
-//   data[`${platformDenom}MarketCap`] = formatMoneyMillions(denomTotalSupplyValue)
-//   data[`${platformDenom}Supply`] = formatMoneyNoDecimalsOrLabels(denomTotalSupplyConverted) + ' ' + denomLabel(platformDenom)
-//
-//   return data;
-// };
+
+var setDenomTotalSupplyValue = async (supplyDataOld, denomPrice, platformDenom) => {
+  let denomTotalSupply;
+  platformDenom === 'bnb' ?
+    denomTotalSupply = bnbAmountOnPlatform(supplyDataOld) :
+    denomTotalSupply = totalAmountOnPlatformByDenom(supplyDataOld, platformDenom)
+  let denomTotalSupplyConverted
+  isKavaNativeAsset(platformDenom) ?
+    denomTotalSupplyConverted = Number(denomTotalSupply)/FACTOR_SIX :
+    denomTotalSupplyConverted = Number(denomTotalSupply)/FACTOR_EIGHT
+  let denomTotalSupplyValue =  Number(denomTotalSupplyConverted * denomPrice)
+
+  let data = {}
+  data[`${platformDenom}Usd`] = denomTotalSupplyValue
+  data[`${platformDenom}MarketCap`] = formatMoneyMillions(denomTotalSupplyValue)
+  data[`${platformDenom}Supply`] = formatMoneyNoDecimalsOrLabels(denomTotalSupplyConverted) + ' ' + denomLabel(platformDenom)
+
+  return data;
+};
 
 const setSupplyDisplayValues = async (denoms, siteData, cssIds) => {
   const defiCoinsSupply = siteData['defiCoinsSupply']


### PR DESCRIPTION
:zap: [Asana Task](https://app.asana.com/0/1200070757865857/1200903628929301)

## What Changes

1. Add row for SWP token on [kava.io/stats](https://www.kava.io/stats) including: 
- SWP price
- Supply & Asset Limit are both fixed at 250 million. 
- Market cap (supply * price) 
2. Trade button should link to [ascendex pool](https://ascendex.com/en/basic/cashtrade-spottrading/usdt/swp)
3. Total market cap stat at the top should include SWP marketcap
4. SWP price change will be handled in a separate ticket

## Why

We should display statistics about our new token to users  

## Preview Link
[https://kava-staging-a4abd63a87a567e70.webflow.io/stats](https://kava-staging-a4abd63a87a567e70.webflow.io/stats
)