### PR TITLE
Swap Page Statistics

### DIFF
--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -1,0 +1,247 @@
+const FACTOR_SIX = Number(10 ** 6);
+const FACTOR_EIGHT = Number(10 ** 8);
+const BASE_URL = "https://api.kava.io";
+
+const usdFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+const isKavaNativeAsset = (denom) => {
+  return ['ukava-a', 'usdx', 'hard', 'ukava', 'hard-a', 'swp-a'].includes(denom);
+}
+
+const setConversionFactors = (denoms) => {
+  const denomConversions = {};
+  for (const denom of denoms) {
+    if (isKavaNativeAsset(denom)) {
+      denomConversions[denom] = FACTOR_SIX;
+    } else {
+      denomConversions[denom] = FACTOR_EIGHT;
+    }
+  }
+  return denomConversions;
+}
+
+const noDollarSign = (value) => {
+  return value.slice(1, value.length);
+}
+
+const displayInMillions = (value) => {
+  const valueInMil = value/FACTOR_SIX;
+  const valueInMilUsd = usdFormatter.format(valueInMil);
+  return valueInMilUsd + "M";
+}
+
+const displayInThousands = (value) => {
+  const valueInK = value/Number(10 ** 3);
+  const valueInKUsd = usdFormatter.format(valueInK);
+  return valueInKUsd + "K";
+}
+
+const formatCssId = (value, denom) => {
+  let displayDenom;
+  switch(denom) {
+    case 'xrpb-a':
+      displayDenom = denom.split('b-')[0]
+      break;
+    case 'ukava-a':
+      displayDenom = 'kava'
+      break;
+    default:
+      displayDenom = denom.split('-')[0]
+      break;
+  }
+
+  return `${value}-${displayDenom}`.toUpperCase();
+}
+
+function formatCoins(coins) {
+  let formattedCoins = {};
+  for (const coin of coins) {
+    formattedCoins[commonDenomMapper(coin.denom)] = { denom: coin.denom, amount: coin.amount }
+  }
+  return formattedCoins;
+}
+
+const formatPercentage = (value) => {
+  return value +"%";
+};
+
+const getRewardPerYearByDenom = async (siteData) => {
+  const incentiveParams = siteData['incentiveParams'];
+  const hardData = incentiveParams.hard_supply_reward_periods;
+  let tokensDistributedBySuppliedAssetPerYear = {};
+  const denomConversions = siteData['denomConversions'];
+  for (const period of hardData) {
+    const coins = {};
+    for (const reward of period.rewards_per_second) {
+      // 31536000 = seconds in a year
+      const coinPerYear = Number(reward.amount) * 31536000 / denomConversions[commonDenomMapper(reward.denom)];
+
+      const coinRewardPerYear = { denom: reward.denom, amount: String(coinPerYear) };
+
+      coins[commonDenomMapper(reward.denom)] = coinRewardPerYear;
+    }
+    tokensDistributedBySuppliedAssetPerYear[commonDenomMapper(period.collateral_type)] =  coins;
+  }
+  return tokensDistributedBySuppliedAssetPerYear;
+}
+
+const setDisplayValueById = (cssId, value) => {
+  const element = document.getElementById(cssId)
+  if (element) { element.innerHTML = value; }
+}
+
+const commonDenomMapper = (denom) => {
+  let formattedDenom;
+  switch(denom.toLowerCase()) {
+    case 'btc':
+      formattedDenom = 'btcb-a';
+      break;
+    case 'usdx':
+      formattedDenom = denom;
+      break;
+    case 'kava':
+      formattedDenom = 'ukava-a';
+      break;
+    case 'xrp':
+      formattedDenom = 'xrpb-a';
+      break;
+    default:
+      formattedDenom = denom + '-a';
+      break;
+  }
+  return formattedDenom;
+}
+
+const mapPrices = async (denoms, pricefeedResult) => {
+  // for now drop any of the usd:30 prices returned
+  const nonThirtyPrices = pricefeedResult.filter(p => !p.market_id.includes('30'));
+  let prices = {};
+
+  let mappedPrices = {};
+  for (const price of nonThirtyPrices) {
+    const priceName = price.market_id.split(":")[0];
+    mappedPrices[commonDenomMapper(priceName)] = { price: Number(price.price)};
+
+    // hbtc doesn't have it's own price, it just uses btc's price
+    if (commonDenomMapper(priceName) === 'btcb-a') {
+      mappedPrices['hbtc-a'] = { price: Number(price.price)};
+    }
+  }
+
+  for ( const denom of denoms) {
+    let mappedPrice = mappedPrices[denom];
+    let price = { price: 0 };
+
+    if(mappedPrice) {
+      price = { price: mappedPrice.price };
+    }
+    prices[denom] = price;
+  }
+  return prices;
+};
+
+const mapCssIds = (denoms) => {
+  let ids = {}
+  // total asset value
+  ids['TAV'] = 'TAV';
+
+
+  // for the market overview table
+  for (const denom of denoms) {
+    ids[denom] = {};
+    ids[denom].totalValueLocked = formatCssId('tvl', denom);
+    ids[denom].rewardApy = formatCssId('rapy', denom);
+  }
+  return ids;
+}
+
+const setTotalAssetValueDisplayValue = async (siteData, cssIds) => {
+  //  pull data from siteData
+
+  let totalAssetValue = 0;
+  for (const coin in balances) {
+    const currencyAmount = Number(balances[coin].amount)/ denomConversions[coin];
+    const price = prices[coin].price;
+    totalAssetValue += Number(currencyAmount * price);
+  }
+  const totalAssetValueUsd = usdFormatter.format(totalAssetValue);
+  setDisplayValueById(cssId, totalAssetValueUsd);
+}
+
+
+
+const setRewardApyDisplayValue = async (denoms, siteData, cssIds) => {
+  //  pull data from siteData
+
+  for (const denom of denoms) {
+    const collatDenomPrice = prices[denom].price;
+    let balanceAmount = 0;
+    if (balances[denom]) {
+      balanceAmount= Number(balances[denom].amount)
+    }
+    const balanceCurrency = balanceAmount / denomConversions[denom];
+    const reward = hardSupplyRewardsPerYearByDenom[denom];
+
+    let numerator = 0;
+    for (const rewardDenom in reward) {
+      const denomPrice = prices[rewardDenom].price;
+      numerator += Number(reward[rewardDenom].amount) * denomPrice;
+    }
+    const denominator = balanceCurrency * collatDenomPrice;
+    let apy = '0.00%';
+
+    if (denominator !==0) {
+      // use usdFormatter to truncate to 2 decimals and round
+      const apyWithDollarSign = usdFormatter.format((numerator / denominator) * 100);
+      apy = formatPercentage(noDollarSign(apyWithDollarSign));
+    }
+    const cssId = cssIds[denom].rewardApy;
+    setDisplayValueById(cssId, apy)
+  }
+};
+
+
+
+const updateDisplayValues = async(denoms) => {
+  const [
+    //  responses
+  ] = await Promise.all([
+    //  API calls
+  ]);
+
+  let siteData = {};
+  const cssIds = mapCssIds(denoms);
+
+
+//  Feed this into siteData
+
+  // set display values in ui
+  await setTotalAssetValueDisplayValue(siteData, cssIds);
+  await setTotalHardDistributedDisplayValue(siteData, cssIds);
+  await setTotalSuppliedDisplayValues(denoms, siteData, cssIds);
+  await setTotalBorrowedDisplayValues(denoms, siteData, cssIds);
+  await setRewardApyDisplayValue(denoms, siteData, cssIds);
+  await setSupplyApyDisplayValue(denoms, siteData, cssIds);
+
+  $(".metric-blur").css("background-color", "transparent")
+  $(".metric-blur").addClass('without-after');
+  $(".api-metric").css({"display": "block", "text-align": "center"})
+}
+
+const main = async () => {
+  const denoms = [
+    'bnb-a', 'btcb-a', 'busd-a',
+    'xrpb-a', 'hard-a', 'usdx',
+    'ukava-a', 'swp-a'
+  ];
+  await updateDisplayValues(denoms);
+  await sleep(30000);
+  main();
+};
+
+const sleep = (ms = 10000) => { return new Promise(resolve => setTimeout(resolve, ms)); };
+
+main();

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -39,21 +39,21 @@ const displayInThousands = (value) => {
   return valueInKUsd + "K";
 }
 
-const formatCssId = (value, denom) => {
-  let displayDenom;
-  switch(denom) {
-    case 'xrpb-a':
-      displayDenom = denom.split('b-')[0]
-      break;
-    case 'ukava-a':
-      displayDenom = 'kava'
-      break;
-    default:
-      displayDenom = denom.split('-')[0]
-      break;
-  }
+const formatCssId = (value, pool) => {
+  // let displayPool;
+  // switch(displayPool) {
+  //   case 'xrpb-a':
+  //     displayDenom = denom.split('b-')[0]
+  //     break;
+  //   case 'ukava-a':
+  //     displayDenom = 'kava'
+  //     break;
+  //   default:
+  //     displayDenom = denom.split('-')[0]
+  //     break;
+  // }
 
-  return `${value}-${displayDenom}`.toUpperCase();
+  return `${value}-${pool}`.toUpperCase();
 }
 
 // function formatCoins(coins) {
@@ -64,10 +64,10 @@ const formatCssId = (value, denom) => {
 //   return formattedCoins;
 // }
 
-//  Todo - helper function that formats pools by removing the '-a' from usdx
-const formatPoolName = (pool) => {
-  return pool.replace(/[-a]/gm, '')
-}
+// //  Todo - helper function that formats pools by removing the '-a' from usdx
+// const formatPoolName = (pool) => {
+//   return pool.replace(/[-a]/gm, '')
+// }
 
 //  Todo helper that finds the non usdx denom in a pool listing
 const findNonUsdxTokenInPool = (pool) => {
@@ -224,7 +224,9 @@ const setTotalValueLockedDisplayValue = async (siteData, cssIds) => {
     totalValueLocked += totalValueLockedByPool[pool].totalValueLocked;
 
     const totalValueLockedUsd = usdFormatter.format(totalValueLocked);
-    const cssId = cssIds[totalValueLockedByPool[pool]]['tvl'];
+    // const cssId = cssIds[[totalValueLockedByPool[pool]]['totalValueLocked']];
+    const cssId = cssIds[pool].totalValueLocked;
+
     setDisplayValueById(cssId, totalValueLockedUsd);
   }
 };
@@ -244,7 +246,8 @@ const setRewardApyDisplayValue = async (pools, siteData, cssIds) => {
   const swpRewardsPerYearByPool = siteData['swpRewardsPerYearByPool']
 
   for (const pool of pools) {
-    const nonUsdxAsset = pool.split(':')[0] !== 'usdx-a' ? pool.split(':')[0] : pool.split(':')[1];
+    const nonUsdxAsset = pool.split(':')[0] !== 'usdx' ? pool.split(':')[0] : pool.split(':')[1];
+    // const nonUsdxAsset = findNonUsdxTokenInPool(pool);
     const suppliedDenomPrice = prices[commonDenomMapper(nonUsdxAsset)].price;
     let tvlAmount = 0;
     if (totalValueLockedPerPool[pool]) {
@@ -313,6 +316,7 @@ const updateDisplayValues = async(denoms, pools) => {
   siteData['swpRewardsPerYearByPool'] = swpRewardsPerYearByPool;
 
   console.log(siteData)
+  console.log(cssIds)
 
   // set display values in ui
   await setTotalAssetValueDisplayValue(siteData, cssIds);
@@ -332,9 +336,9 @@ const main = async () => {
   ];
 
   const pools = [
-    'bnb:usdx-a', 'btcb:usdx-a', 'busd:usdx-a',
-    'usdx-a:xrpb', 'hard:usdx-a',
-    'ukava:usdx-a', 'swp:usdx-a'
+    'bnb:usdx', 'btcb:usdx', 'busd:usdx',
+    'usdx:xrpb', 'hard:usdx',
+    'ukava:usdx', 'swp:usdx'
   ];
 
   await updateDisplayValues(denoms, pools);

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -182,28 +182,32 @@ const mapCssIds = (pools) => {
   return ids;
 }
 
-// const setTotalAssetValueDisplayValue = async (siteData, cssIds) => {
-//   //  pull data from siteData
-//
-//   let totalAssetValue = 0;
-//   for (const coin in balances) {
-//     const currencyAmount = Number(balances[coin].amount)/ denomConversions[coin];
-//     const price = prices[coin].price;
-//     totalAssetValue += Number(currencyAmount * price);
-//   }
-//   const totalAssetValueUsd = usdFormatter.format(totalAssetValue);
-//   setDisplayValueById(cssId, totalAssetValueUsd);
-// }
-//
-// const setTotalValueLockedDisplayValue = async (siteData, cssIds) => {
-//   //  pull data from siteData
-//   //  loop through denoms
-//   //  format data in USD
-//   const totalValueLockedUsd = usdFormatter.format(totalAssetValue);
-//
-//   setDisplayValueById(cssId, totalValueLockedUsd);
-//
-// }
+//  sum of all assets in all pools
+const setTotalAssetValueDisplayValue = async (siteData, cssIds) => {
+  const cssId = cssIds['TAV'];
+  const totalValueLockedByPool = siteData['swpPoolData'];
+
+  let totalAssetValue = 0;
+  for (const pool in totalValueLockedByPool) {
+    totalAssetValue += pool.totalValueLocked;
+  }
+  const totalAssetValueUsd = usdFormatter.format(totalAssetValue);
+  setDisplayValueById(cssId, totalAssetValueUsd);
+};
+
+//  sum of assets in individual pools
+const setTotalValueLockedDisplayValue = async (siteData, cssIds) => {
+  const totalValueLockedByPool = siteData['swpPoolData'];
+
+  for (const pool in totalValueLockedByPool) {
+    let totalValueLocked = 0;
+    totalValueLocked += pool.totalValueLocked;
+
+    const totalValueLockedUsd = usdFormatter.format(totalValueLocked);
+    const cssId = cssIds[pool]['tvl'];
+    setDisplayValueById(cssId, totalValueLockedUsd);
+  }
+};
 
 const setSwpPrice = async (swpMarketJson) => {
   const swpPriceInUSD = swpMarketJson.market_data.current_price.usd;
@@ -270,9 +274,6 @@ const updateDisplayValues = async(denoms, pools) => {
   const pricefeedPrices = await pricefeedResponse.json();
   const incentiveParamsJson = await incentiveParametersResponse.json();
 
-  const rewardApy = {};
-  siteData['rewardApy'] = rewardApy
-
   const prices = await mapPrices(denoms, pricefeedPrices.result);
   siteData['prices'] = prices;
 
@@ -294,8 +295,8 @@ const updateDisplayValues = async(denoms, pools) => {
   console.log(siteData)
 
   // set display values in ui
-  // await setTotalAssetValueDisplayValue(siteData, cssIds);
-  // await setTotalValueLockedDisplayValue(siteData, cssIds);
+  await setTotalAssetValueDisplayValue(siteData, cssIds);
+  await setTotalValueLockedDisplayValue(siteData, cssIds);
   await setRewardApyDisplayValue(pools, siteData, cssIds);
 
   $(".metric-blur").css("background-color", "transparent")

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -99,7 +99,7 @@ const getRewardsPerYearByPool = async (siteData) => {
 
       coins[commonDenomMapper(reward.denom)] = coinRewardPerYear;
     }
-    tokensDistributedBySuppliedAssetPerYear[commonDenomMapper(period.collateral_type)] =  coins;
+    tokensDistributedBySuppliedAssetPerYear[period.collateral_type] =  coins;
   }
   return tokensDistributedBySuppliedAssetPerYear;
 }
@@ -177,7 +177,8 @@ const mapSwpPoolData =  (denoms, siteData, swpPoolDataJson) => {
     const usdxAssetValue = Number(usdxAsset.amount) / FACTOR_SIX * prices['usdx'].price
 
     coinMap[pool.name] = {
-      totalValueLocked: nonUsdxAssetValue + usdxAssetValue
+      totalValueLocked: nonUsdxAssetValue + usdxAssetValue,
+      totalShares: Number(pool.total_shares)
     };
 
     return coinMap;
@@ -253,7 +254,7 @@ const setRewardApyDisplayValue = async (pools, siteData, cssIds) => {
     if (totalValueLockedPerPool[pool]) {
       tvlAmount= Number(totalValueLockedPerPool[pool].totalValueLocked)
     }
-    const balanceCurrency = tvlAmount / denomConversions[nonUsdxAsset];
+    const balanceCurrency = tvlAmount / denomConversions[nonUsdxAsset + '-a'];
     const reward = swpRewardsPerYearByPool[pool];
 
     let numerator = 0;

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -46,11 +46,11 @@ const formatPercentage = (value) => {
 };
 
 const getRewardsPerYearByPool = async (siteData) => {
-  const incentiveParams = siteData['incentiveParams'];
-  const swapData = incentiveParams.swap_reward_periods;
-  let tokensDistributedBySuppliedAssetPerYear = {};
+  const swapRewardPeriods = siteData['incentiveParams'].swap_reward_periods;
   const denomConversions = siteData['denomConversions'];
-  for (const period of swapData) {
+
+  let tokensDistributedBySuppliedAssetPerYear = {};
+  for (const period of swapRewardPeriods) {
     const coins = {};
     for (const reward of period.rewards_per_second) {
       // 31536000 = seconds in a year

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -56,13 +56,17 @@ const formatCssId = (value, denom) => {
   return `${value}-${displayDenom}`.toUpperCase();
 }
 
-function formatCoins(coins) {
-  let formattedCoins = {};
-  for (const coin of coins) {
-    formattedCoins[commonDenomMapper(coin.denom)] = { denom: coin.denom, amount: coin.amount }
-  }
-  return formattedCoins;
-}
+// function formatCoins(coins) {
+//   let formattedCoins = {};
+//   for (const coin of coins) {
+//     formattedCoins[commonDenomMapper(coin.denom)] = { denom: coin.denom, amount: coin.amount }
+//   }
+//   return formattedCoins;
+// }
+
+//  Todo - helper function that formats pools by removing the usdx
+
+//  Todo helper that finds the non usdx denom in a pool listing
 
 const formatPercentage = (value) => {
   return value +"%";
@@ -91,6 +95,7 @@ const getRewardsPerYearByPool = async (siteData) => {
 const setDisplayValueById = (cssId, value) => {
   const element = document.getElementById(cssId)
   if (element) { element.innerHTML = value; }
+  console.log(cssId, value)
 }
 
 const commonDenomMapper = (denom) => {

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -133,7 +133,7 @@ const mapSwpPoolData =  (denoms, siteData, swpPoolDataJson) => {
     const factor = denomConversions[formattedNonUsdxDenom];
 
     const nonUsdxAssetValue = Number(nonUsdxAsset.amount) / factor * prices[formattedNonUsdxDenom].price;
-    const usdxAssetValue = Number(usdxAsset.amount) / FACTOR_SIX * prices['usdx'].price
+    const usdxAssetValue = Number(usdxAsset.amount) / FACTOR_SIX * prices['usdx'].price;
 
     coinMap[pool.name] = {
       totalValueLocked: nonUsdxAssetValue + usdxAssetValue,
@@ -258,8 +258,8 @@ const updateDisplayValues = async(denoms, pools) => {
   const swpPrice = await setSwpPrice(swpMarketJson.market_data);
   siteData['prices']['swp-a'] = swpPrice;
 
-  const swpPoolData = await mapSwpPoolData(denoms, siteData, swpPoolDataJson)
-  siteData['swpPoolData'] = swpPoolData
+  const swpPoolData = await mapSwpPoolData(denoms, siteData, swpPoolDataJson);
+  siteData['swpPoolData'] = swpPoolData;
 
   const swpRewardsPerYearByPool = await getRewardsPerYearByPool(siteData);
   siteData['swpRewardsPerYearByPool'] = swpRewardsPerYearByPool;

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -132,7 +132,7 @@ const mapSwpPoolData =  (denoms, siteData, swpPoolDataJson) => {
 
     const factor = denomConversions[formattedNonUsdxDenom];
 
-    const nonUsdxAssetValue = nonUsdxAsset.amount / factor * prices[formattedNonUsdxDenom].price;
+    const nonUsdxAssetValue = Number(nonUsdxAsset.amount) / factor * prices[formattedNonUsdxDenom].price;
     const usdxAssetValue = Number(usdxAsset.amount) / FACTOR_SIX * prices['usdx'].price
 
     coinMap[pool.name] = {

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -179,8 +179,11 @@ const setTVLAndTAVDisplayValues = async (siteData, cssIds) => {
 };
 
 
-const setSwpPrice = async (swpMarketJson) => {
-  const swpPriceInUSD = swpMarketJson.market_data.current_price.usd;
+const setSwpPrice = async (swpMarketData) => {
+  let swpPriceInUSD = 0;
+  if (swpMarketData) {
+    swpPriceInUSD = swpMarketData.current_price.usd;
+  }
 
   return {
     price: swpPriceInUSD
@@ -234,7 +237,7 @@ const updateDisplayValues = async(denoms, pools) => {
     fetch(`${BASE_URL}/swap/pools`),
   ]);
 
-  const swpMarketDataJson = await swpMarketResponse.json();
+  const swpMarketJson = await swpMarketResponse.json();
   const swpPoolDataJson = await swpPoolsResponse.json();
 
   let siteData = {};
@@ -252,7 +255,7 @@ const updateDisplayValues = async(denoms, pools) => {
   const incentiveParams = await incentiveParamsJson.result;
   siteData['incentiveParams'] = incentiveParams;
 
-  const swpPrice = await setSwpPrice(swpMarketDataJson);
+  const swpPrice = await setSwpPrice(swpMarketJson.market_data);
   siteData['prices']['swp-a'] = swpPrice;
 
   const swpPoolData = await mapSwpPoolData(denoms, siteData, swpPoolDataJson)

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -64,9 +64,21 @@ const formatCssId = (value, denom) => {
 //   return formattedCoins;
 // }
 
-//  Todo - helper function that formats pools by removing the usdx
+//  Todo - helper function that formats pools by removing the '-a' from usdx
+const formatPoolName = (pool) => {
+  return pool.replace(/[-a]/gm, '')
+}
 
 //  Todo helper that finds the non usdx denom in a pool listing
+const findNonUsdxTokenInPool = (pool) => {
+  const nonUsdxAsset = pool.coins[0].denom !== 'usdx' ? pool.coins[0] : pool.coins[1];
+  return nonUsdxAsset;
+};
+
+const findUsdxTokenInPool = (pool) => {
+  const usdxAsset = pool.coins[0].denom === 'usdx' ? pool.coins[0] : pool.coins[1];
+  return usdxAsset;
+}
 
 const formatPercentage = (value) => {
   return value +"%";
@@ -93,9 +105,10 @@ const getRewardsPerYearByPool = async (siteData) => {
 }
 
 const setDisplayValueById = (cssId, value) => {
+  console.log(cssId, value)
+
   const element = document.getElementById(cssId)
   if (element) { element.innerHTML = value; }
-  console.log(cssId, value)
 }
 
 const commonDenomMapper = (denom) => {
@@ -153,8 +166,8 @@ const mapSwpPoolData =  (denoms, siteData, swpPoolDataJson) => {
   const denomConversions = siteData['denomConversions'];
 
   const coins = swpPoolDataJson.result.reduce((coinMap, pool) => {
-    const nonUsdxAsset = pool.coins[0].denom !== 'usdx' ? pool.coins[0] : pool.coins[1];
-    const usdxAsset = pool.coins[0].denom === 'usdx' ? pool.coins[0] : pool.coins[1];
+    const nonUsdxAsset = findNonUsdxTokenInPool(pool);
+    const usdxAsset = findUsdxTokenInPool(pool);
 
     const formattedNonUsdxDenom = commonDenomMapper(nonUsdxAsset.denom);
 
@@ -196,7 +209,7 @@ const setTotalAssetValueDisplayValue = async (siteData, cssIds) => {
 
   let totalAssetValue = 0;
   for (const pool in totalValueLockedByPool) {
-    totalAssetValue += pool.totalValueLocked;
+    totalAssetValue += totalValueLockedByPool[pool].totalValueLocked;
   }
   const totalAssetValueUsd = usdFormatter.format(totalAssetValue);
   setDisplayValueById(cssId, totalAssetValueUsd);
@@ -208,10 +221,10 @@ const setTotalValueLockedDisplayValue = async (siteData, cssIds) => {
 
   for (const pool in totalValueLockedByPool) {
     let totalValueLocked = 0;
-    totalValueLocked += pool.totalValueLocked;
+    totalValueLocked += totalValueLockedByPool[pool].totalValueLocked;
 
     const totalValueLockedUsd = usdFormatter.format(totalValueLocked);
-    const cssId = cssIds[pool]['tvl'];
+    const cssId = cssIds[totalValueLockedByPool[pool]]['tvl'];
     setDisplayValueById(cssId, totalValueLockedUsd);
   }
 };

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -150,22 +150,17 @@ const mapSwpPoolData =  (denoms, siteData, swpPoolDataJson) => {
 
   const coins = swpPoolDataJson.result.reduce((coinMap, pool) => {
     const nonUsdxAsset = pool.coins[0].denom !== 'usdx' ? pool.coins[0] : pool.coins[1];
+    const formattedNonUsdxDenom = commonDenomMapper(nonUsdxAsset.denom);
     const usdxAsset = pool.coins[0].denom === 'usdx' ? pool.coins[0] : pool.coins[1];
 
-    const formattedNonUsdxDenom = commonDenomMapper(nonUsdxAsset.denom);
     const factor = isKavaNativeAsset(formattedNonUsdxDenom) ? FACTOR_SIX : FACTOR_EIGHT;
 
-    coinMap[formattedNonUsdxDenom] = {
-      denom: formattedNonUsdxDenom,
-      amount: Number(nonUsdxAsset.amount) / factor,
-      value: Number(nonUsdxAsset.amount) / factor * prices[formattedNonUsdxDenom].price
-    };
+    const nonUsdxAssetValue = nonUsdxAsset.amount / factor * prices[formattedNonUsdxDenom].price;
+    const usdxAssetValue = Number(usdxAsset.amount) / FACTOR_SIX * prices['usdx'].price
 
-    coinMap.usdx = {
-      denom: 'usdx',
-      amount: usdxAmount += (Number(usdxAsset.amount) / FACTOR_SIX),
-      value: usdxAmount * prices['usdx'].price
-    }
+    coinMap[pool.name] = {
+      totalValueLocked: nonUsdxAssetValue + usdxAssetValue
+    };
 
     return coinMap;
   }, {});

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -182,6 +182,8 @@ const mapCssIds = (pools) => {
   return ids;
 }
 
+//  todo - when these are tested, refactor into single function that sets both
+//  tav and tvl ids in one pass through the tVLBP
 //  sum of all assets in all pools
 const setTotalAssetValueDisplayValue = async (siteData, cssIds) => {
   const cssId = cssIds['TAV'];


### PR DESCRIPTION
:zap: [Asana Task](https://app.asana.com/0/1200070757865857/1200935360653042)

## What Changes

1. New script file to support live-updating statistics on kava.io/swap
2. Follows the pattern of the other webflow script files
3. Calculate the following statistics:
- Total Asset Value in all pools combined
- Total Value Locked in each pool
- Reward APY for each pool

## Why

There are no live statistics on [kava.io/swap](kava.io/swap) yet.

## Feedback Requested

- Do I create all of the necessary empty records to guard against a failed page load?
- Are there opportunities to improve performance by eliminating any unnecessary looping through pools?

## Dependencies
Waiting on design to be able to publish these changes in Webflow (estimated 9/15-9/16), but in the meantime I've logged out the data points and the corresponding CSS id's so the values can be verified against what is displayed on [app.kava.io/swap](app.kava.io/swap) and things look to be matching up.

<img width="278" alt="Screen Shot 2021-09-13 at 3 57 36 PM" src="https://user-images.githubusercontent.com/67024033/133155397-cf8fb2e9-e732-4bad-afac-719af6ac9e3c.png">

<img width="795" alt="Screen Shot 2021-09-13 at 3 58 07 PM" src="https://user-images.githubusercontent.com/67024033/133155470-4bd8a25c-209d-48b2-9604-75d61600ceca.png">


