### PR TITLE
Adjust pool name formatting

### DIFF
--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -280,7 +280,7 @@ const main = async () => {
   ];
 
   const pools = [
-    'bnb:usdx', 'btcb:usdx', 'busd:usdx',
+    'bnbusdx', 'btcb:usdx', 'busd-usdx',
     'usdx:xrpb', 'hard:usdx',
     'ukava:usdx', 'swp:usdx'
   ];

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -25,10 +25,14 @@ const setConversionFactors = (denoms) => {
 
 const noDollarSign = (value) => {
   return value.slice(1, value.length);
-}
+};
 
 const formatCssId = (value, pool) => {
   return `${value}-${pool}`.toUpperCase();
+};
+
+const formatPoolName = (pool) => {
+  return pool.replace(/\:/gm, '-');
 }
 
 const findNonUsdxTokenInPool = (pool) => {
@@ -158,17 +162,18 @@ const mapCssIds = (pools) => {
   return ids;
 }
 
-const setTVLAndTAVDisplayValues = async (siteData, cssIds, pools) => {
+const setTVLAndTAVDisplayValues = async (siteData, cssIds) => {
   const cssIdTAV = cssIds['TAV'];
   const totalValueLockedByPool = siteData['swpPoolData'];
 
   let totalAssetValue = 0;
-  for (const pool of pools) {
+  for (const pool in totalValueLockedByPool) {
     let totalValueLocked = 0;
     totalValueLocked += totalValueLockedByPool[pool].totalValueLocked;
 
     const totalValueLockedUsd = usdFormatter.format(totalValueLocked);
-    const cssIdTVL = cssIds[pool].totalValueLocked;
+    // const formattedPool = pool.replace(/\:/gm, '-');
+    const cssIdTVL = cssIds[formatPoolName(pool)].totalValueLocked;
     setDisplayValueById(cssIdTVL, totalValueLockedUsd);
 
     totalAssetValue += totalValueLockedByPool[pool].totalValueLocked;
@@ -195,7 +200,8 @@ const setRewardApyDisplayValue = async (pools, siteData, cssIds) => {
   const swpPoolData = siteData['swpPoolData'];
   const swpRewardsPerYearByPool = siteData['swpRewardsPerYearByPool'];
 
-  for (const pool of pools) {
+
+  for (const pool in swpPoolData) {
     let tvlAmount = 0;
     if (swpPoolData[pool].totalValueLocked) {
       tvlAmount = Number(swpPoolData[pool].totalValueLocked);
@@ -219,7 +225,7 @@ const setRewardApyDisplayValue = async (pools, siteData, cssIds) => {
       rewardApy = formatPercentage(noDollarSign(apyWithDollarSign));
     }
 
-    const cssId = cssIds[pool].rewardApy;
+    const cssId = cssIds[formatPoolName(pool)].rewardApy;
     setDisplayValueById(cssId, rewardApy);
   }
 };
@@ -264,7 +270,7 @@ const updateDisplayValues = async(denoms, pools) => {
   const swpRewardsPerYearByPool = await getRewardsPerYearByPool(siteData);
   siteData['swpRewardsPerYearByPool'] = swpRewardsPerYearByPool;
 
-  await setTVLAndTAVDisplayValues(siteData, cssIds, pools);
+  await setTVLAndTAVDisplayValues(siteData, cssIds);
   await setRewardApyDisplayValue(pools, siteData, cssIds);
 
   $(".metric-blur").css("background-color", "transparent");

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -158,12 +158,12 @@ const mapCssIds = (pools) => {
   return ids;
 }
 
-const setTVLAndTAVDisplayValues = async (siteData, cssIds) => {
+const setTVLAndTAVDisplayValues = async (siteData, cssIds, pools) => {
   const cssIdTAV = cssIds['TAV'];
   const totalValueLockedByPool = siteData['swpPoolData'];
 
   let totalAssetValue = 0;
-  for (const pool in totalValueLockedByPool) {
+  for (const pool in pools) {
     let totalValueLocked = 0;
     totalValueLocked += totalValueLockedByPool[pool].totalValueLocked;
 
@@ -264,7 +264,7 @@ const updateDisplayValues = async(denoms, pools) => {
   const swpRewardsPerYearByPool = await getRewardsPerYearByPool(siteData);
   siteData['swpRewardsPerYearByPool'] = swpRewardsPerYearByPool;
 
-  await setTVLAndTAVDisplayValues(siteData, cssIds);
+  await setTVLAndTAVDisplayValues(siteData, cssIds, pools);
   await setRewardApyDisplayValue(pools, siteData, cssIds);
 
   $(".metric-blur").css("background-color", "transparent");

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -285,9 +285,9 @@ const main = async () => {
   ];
 
   const pools = [
-    'bnb-usdx', 'btcb-usdx', 'busd-usdx',
-    'usdx-xrpb', 'hard-usdx',
-    'ukava-usdx', 'swp-usdx'
+    'bnb:usdx', 'btcb:usdx', 'busd:usdx',
+    'usdx:xrpb', 'hard:usdx',
+    'ukava:usdx', 'swp:usdx'
   ];
 
   await updateDisplayValues(denoms, pools);

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -285,9 +285,9 @@ const main = async () => {
   ];
 
   const pools = [
-    'bnb:usdx', 'btcb:usdx', 'busd:usdx',
-    'usdx:xrpb', 'hard:usdx',
-    'ukava:usdx', 'swp:usdx'
+    'bnb-usdx', 'btcb-usdx', 'busd-usdx',
+    'usdx-xrpb', 'hard-usdx',
+    'ukava-usdx', 'swp-usdx'
   ];
 
   await updateDisplayValues(denoms, pools);

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -163,7 +163,7 @@ const setTVLAndTAVDisplayValues = async (siteData, cssIds, pools) => {
   const totalValueLockedByPool = siteData['swpPoolData'];
 
   let totalAssetValue = 0;
-  for (const pool in pools) {
+  for (const pool of pools) {
     let totalValueLocked = 0;
     totalValueLocked += totalValueLockedByPool[pool].totalValueLocked;
 

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -171,10 +171,9 @@ const setTVLAndTAVDisplayValues = async (siteData, cssIds) => {
     let totalValueLocked = 0;
     totalValueLocked += totalValueLockedByPool[pool].totalValueLocked;
 
-    const totalValueLockedUsd = usdFormatter.format(totalValueLocked);
-    // const formattedPool = pool.replace(/\:/gm, '-');
+    // const totalValueLockedUsd = usdFormatter.format(totalValueLocked);
     const cssIdTVL = cssIds[formatPoolName(pool)].totalValueLocked;
-    setDisplayValueById(cssIdTVL, totalValueLockedUsd);
+    setDisplayValueById(cssIdTVL, totalValueLocked);
 
     totalAssetValue += totalValueLockedByPool[pool].totalValueLocked;
   }

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -171,14 +171,14 @@ const setTVLAndTAVDisplayValues = async (siteData, cssIds) => {
     let totalValueLocked = 0;
     totalValueLocked += totalValueLockedByPool[pool].totalValueLocked;
 
-    // const totalValueLockedUsd = usdFormatter.format(totalValueLocked);
+    const totalValueLockedUsd = usdFormatter.format(totalValueLocked);
     const cssIdTVL = cssIds[formatPoolName(pool)].totalValueLocked;
-    setDisplayValueById(cssIdTVL, totalValueLocked);
+    setDisplayValueById(cssIdTVL, totalValueLockedUsd);
 
     totalAssetValue += totalValueLockedByPool[pool].totalValueLocked;
   }
 
-  const totalAssetValueUsd = usdFormatter.format(totalAssetValue);
+  const totalAssetValueUsd = noDollarSign(usdFormatter.format(totalAssetValue));
   setDisplayValueById(cssIdTAV, totalAssetValueUsd);
 };
 

--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -280,9 +280,9 @@ const main = async () => {
   ];
 
   const pools = [
-    'bnbusdx', 'btcb:usdx', 'busd-usdx',
-    'usdx:xrpb', 'hard:usdx',
-    'ukava:usdx', 'swp:usdx'
+    'bnb-usdx', 'btcb-usdx', 'busd-usdx',
+    'usdx-xrpb', 'hard-usdx',
+    'ukava-usdx', 'swp-usdx'
   ];
 
   await updateDisplayValues(denoms, pools);


### PR DESCRIPTION
Pool names include a colon, which isn't supported in CSS ids [https://www.w3.org/TR/CSS21/syndata.html#characters](https://www.w3.org/TR/CSS21/syndata.html#characters).
Webflow was automatically changing them to hyphens.

- Adjusted the `pools` array from `bnb:usdx` to `bnb-usdx` so we can use them as keys in the `cssIds` object.
- Created a helper function `formatPoolName` that replaces the colon with a hyphen when making the individual ids.

Preview Link: [https://kava-staging-a4abd63a87a567e70.webflow.io/swap](https://kava-staging-a4abd63a87a567e70.webflow.io/swap)