### PR TITLE
Calculating 24 volumes in USD, both total and per pool

### DIFF
--- a/swap-protocol-home.js
+++ b/swap-protocol-home.js
@@ -322,7 +322,7 @@ const updateDisplayValues = async(denoms, pools) => {
 
   await setTVLAndTAVDisplayValues(siteData, cssIds);
   await setRewardApyDisplayValue(pools, siteData, cssIds);
-  await setDailyVolumesDisplayValues(siteData, cssIds)
+  await setDailyVolumesDisplayValues(siteData, cssIds);
 
   $(".metric-blur").css("background-color", "transparent");
   $(".metric-blur").addClass('without-after');


### PR DESCRIPTION
:zap: [Asana Task](https://app.asana.com/0/1200070757865857/1201118632330643)

## What Changes

- Calculating 24 volume (in USD) per pool and total using this endpoint: [https://swap-data.kava.io/v1/pools/internal](https://swap-data.kava.io/v1/pools/internal)
- Mapping those values to CSS id's to implement in Webflow

<img width="255" alt="Screen Shot 2021-10-04 at 2 14 14 PM" src="https://user-images.githubusercontent.com/67024033/135910493-fb18f5f2-75d5-40df-8e28-fbdfcb3fa6b4.png">

## Why

These data points can drive user behavior - the greater the volume, the more rewards from fees.


## Feedback Requested

I was not able to call the endpoint from the browser, so I had to stub out the data for the endpoint and work with that.
Is there a work-around for this or another way to confirm that it's behaving properly?

## Dependencies

- [ ] Waiting on Design to add these metrics to webflow before updating the script.
