### PR TITLE
Adjust TAV to be total supply plus total borrow

### DIFF
--- a/hard-protocol-home.js
+++ b/hard-protocol-home.js
@@ -68,15 +68,6 @@ const formatPercentage = (value) => {
   return value +"%";
 };
 
-const getModuleBalances = async (hardAccounts) => {
-  const hardAccountCoins = hardAccounts.find(a => a.value.name === 'hard').value.coins;
-  const coins = {};
-  for (const coin of hardAccountCoins) {
-    coins[commonDenomMapper(coin.denom)] = { denom: coin.denom, amount: coin.amount };
-  }
-  return coins;
-};
-
 const getRewardPerYearByDenom = async (siteData) => {
   const incentiveParams = siteData['incentiveParams'];
   const hardData = incentiveParams.hard_supply_reward_periods;
@@ -304,14 +295,12 @@ const setSupplyApyDisplayValue = async (denoms, siteData, cssIds) => {
 const updateDisplayValues = async(denoms) => {
   const [
     pricefeedResponse,
-    hardAccountResponse,
     hardTotalSuppliedResponse,
     hardTotalBorrowedResponse,
     incentiveParametersResponse,
     hardInterestRatesResponse
   ] = await Promise.all([
     fetch(`${BASE_URL}/pricefeed/prices`),
-    fetch(`${BASE_URL}/hard/accounts`),
     fetch(`${BASE_URL}/hard/total-deposited`),
     fetch(`${BASE_URL}/hard/total-borrowed`),
     fetch(`${BASE_URL}/incentive/parameters`),
@@ -322,7 +311,6 @@ const updateDisplayValues = async(denoms) => {
   const cssIds = mapCssIds(denoms);
 
   const pricefeedPrices = await pricefeedResponse.json();
-  const hardAccountJson = await hardAccountResponse.json();
   const hardTotalSuppliedJson = await hardTotalSuppliedResponse.json();
   const hardTotalBorrowedJson = await hardTotalBorrowedResponse.json();
   const incentiveParamsJson = await incentiveParametersResponse.json();
@@ -334,9 +322,6 @@ const updateDisplayValues = async(denoms) => {
 
   const denomConversions = setConversionFactors(denoms);
   siteData['denomConversions'] = denomConversions;
-
-  const hardAccount = await getModuleBalances(hardAccountJson.result);
-  siteData['hardAccount'] = hardAccount;
 
   const hardTotalSupplied = formatCoins(hardTotalSuppliedJson.result);
   siteData['hardTotalSupplied'] = hardTotalSupplied;


### PR DESCRIPTION
Rather than calling https://api.kava.io/hard/accounts to calculate TAV for Kava Lend, sum the values from /hard/total-deposited and /hard/total-borrowed. 

[Deploy preview](https://kava-staging-a4abd63a87a567e70.webflow.io/lend) passed the napkin math test and increased TAV from $181M to $224M